### PR TITLE
Keep GitHub workflows up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     - 7.0.0
     - 7.0.1
     - 7.0.2
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
We're currently getting a bunch of warnings about CodeQL being out-of-date. This should help keep stuff up-to-date.